### PR TITLE
Fixed extension test skipping

### DIFF
--- a/ifj2017/tests/02_functions/tests.json
+++ b/ifj2017/tests/02_functions/tests.json
@@ -15,12 +15,12 @@
     {
       "info": "Asc value",
       "stdout": " 104",
-      "code": "scope \n print asc(!\"ahoj\", 2); \n end scope"
+      "code": "scope \n dim a as integer \n a = asc(!\"ahoj\", 2) \n print a; \n end scope"
     },
     {
       "info": "Chr function",
       "stdout": "a",
-      "code": "scope \n print chr(97); \n end scope"
+      "code": "scope \n dim c as string \n c = chr(97) \n print c; \n end scope"
     },
     {
       "info": "function integer implicit return",

--- a/ifj2017/tests/05_conditions/tests.json
+++ b/ifj2017/tests/05_conditions/tests.json
@@ -14,7 +14,10 @@
     },
     {
       "name": "04",
-      "stdout": " 123 74"
+      "stdout": " 123 74",
+      "extensions": [
+        "IFTHEN"
+      ]
     },
     {
       "name": "05",
@@ -57,6 +60,12 @@
       "name": "13",
       "stdout": "? ?  42",
       "stdin": "Ahojky\nAhojky"
+    },
+    {
+      "name": "14",
+      "extensions": [
+        "IFTHEN"
+      ]
     }
   ]
 }


### PR DESCRIPTION
- when section had global extension need in tests.json and test was in file and was not defined in tests.json test was not skipped
- asc() test can now be run without FUNEXP extension
- chr() test can now be run without FUNEXP extension
- tests 09/04 and 09/14 need IFTHEN extension