### PR TITLE
Don't show skipped tests when verbose mode is off.

### DIFF
--- a/ifj2017/test/base.py
+++ b/ifj2017/test/base.py
@@ -23,5 +23,6 @@ class TestReport(object):
 
     success = None
 
+    skipped = None
 
 __all__ = ['TestReport', 'TestInfo']

--- a/ifj2017/test/logger.py
+++ b/ifj2017/test/logger.py
@@ -81,7 +81,7 @@ class TestLogger(object):
     @classmethod
     def log_test_ok(cls):
         cls._test_case_success = True
-        cls.log(cls.GREEN, cls.BOLD, '✓', end=False)
+        cls.log(cls.GREEN, cls.BOLD, '√', end=False)
 
     @classmethod
     def log_warning(cls, warning):
@@ -125,7 +125,7 @@ class TestLogger(object):
             cls.BOLD,
             ''.join(
                 (
-                    (cls.FAIL + '×', cls.GREEN + '✓')[report.success]
+                    (cls.FAIL + '×', cls.GREEN + '√')[report.success]
                     if report.success is not None
                     else cls.BLUE + '-'
                 )

--- a/ifj2017/test/logger.py
+++ b/ifj2017/test/logger.py
@@ -40,7 +40,8 @@ class TestLogger(object):
     verbose = False
 
     _test_case_buffer = None
-    _test_case_success = None
+    _test_case_success = None    
+    _test_case_skipped = None
 
     @classmethod
     def log(cls, *args, stream=sys.stderr, end=True, indent=0):
@@ -89,7 +90,7 @@ class TestLogger(object):
     @classmethod
     def log_end_test_case(cls):
         cls.log()
-        if cls.verbose or not cls._test_case_success:
+        if cls.verbose or not cls._test_case_success and not cls._test_case_skipped:
             cls._log_buffer()
         cls._test_case_buffer = None
 

--- a/ifj2017/test/runner.py
+++ b/ifj2017/test/runner.py
@@ -151,6 +151,7 @@ class TestRunner(object):
     def _run_test(self, test_info):
         report = TestReport()
         report.test_info = test_info
+        report.skipped = None
         TestLogger.log_test(
             test_info.name,
             ' ({})'.format(
@@ -162,6 +163,7 @@ class TestRunner(object):
                 ', '.join(test_info.extensions - self._extensions)
             ), end=False)
             report.success = None
+            report.skipped = True
             self._save_report(test_info, report)
             return
 
@@ -328,6 +330,7 @@ class TestRunner(object):
             ) or '# ---')
         self._reports.append(report)
         TestLogger._test_case_success = report.success
+        TestLogger._test_case_skipped = report.skipped
         TestLogger.log_end_test_case()
 
     @classmethod


### PR DESCRIPTION
Verbose mode shows everything and if verbose mode is off output looks like this:

![image](https://user-images.githubusercontent.com/2041639/33209804-eeea07c0-d117-11e7-9dee-a12cfb0f2f21.png)

Only failed tests are visible.
